### PR TITLE
add impossibility to update not your places & admin can delete places of all users

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/AbcSize
 class PlacesController < ApplicationController
   # before_action :signed_in_user, only: [:create, :destroy]
   # before_action :correct_user,   only: :destroy
@@ -39,6 +40,10 @@ class PlacesController < ApplicationController
   end
 
   def destroy
+    str = request.referer
+    user_id = str.split('/').last
+    @user = User.find_by(id: user_id)
+    @user.places.destroy(params[:id]) if current_user.admin?
     current_user.places.destroy(params[:id])
   end
 
@@ -48,3 +53,4 @@ class PlacesController < ApplicationController
     params.permit(:title, :description, :coordinates, :user_id)
   end
 end
+# rubocop:enable Metrics/AbcSize

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -29,6 +29,11 @@ class PlacesController < ApplicationController
   end
 
   def update
+    str = request.referer
+    user_id = str.split('/').last
+    @user = User.find_by(id: user_id)
+    return unless current_user == @user
+
     @place = Place.find(params[:id])
     @place.update(place_params)
   end


### PR DESCRIPTION
### [Link to the ticket](https://trello.com/c/ujIlzqa8/120-add-impossibility-to-update-not-yourself-places)
### What it does
Fix bug, where current user can update places of another user.
Also add possibility to admin to delete places of all users.